### PR TITLE
Make controller losely typed

### DIFF
--- a/src/main/kotlin/pogolitics/App.kt
+++ b/src/main/kotlin/pogolitics/App.kt
@@ -127,6 +127,7 @@ class App: Component<Props, AppState>() {
     @Suppress("UNCHECKED_CAST")
     private fun ChildrenBuilder.renderPage() {
         return if (state.controllerResult!!.isModelAndView) {
+            // TODO try to eliminate casting while keeping model and view type safe
             // view must be not null if isModelAndView == true
             val component = state.controllerResult!!.view!! as KClass<out Component<PageRProps<Any?, *>, out State>>
             component.react {

--- a/src/main/kotlin/pogolitics/App.kt
+++ b/src/main/kotlin/pogolitics/App.kt
@@ -23,7 +23,7 @@ import react.dom.html.ReactHTML.img
 import kotlin.reflect.KClass
 
 external interface AppState : State {
-    var controllerResult: ControllerResult<*, *>?
+    var controllerResult: LooselyTypedControllerResult?
     var url: String?
     var pageState: Any?
     var pageStateChanged: Boolean

--- a/src/main/kotlin/pogolitics/App.kt
+++ b/src/main/kotlin/pogolitics/App.kt
@@ -55,7 +55,7 @@ class App: Component<Props, AppState>() {
         }
     }
 
-    private fun <M, S> ChildrenBuilder.routeToPage(route: AppConfig.Route<M, S>) {
+    private fun <S> ChildrenBuilder.routeToPage(route: AppConfig.Route<S>) {
         Route {
             path = route.path
             element = wrapInFc {
@@ -67,7 +67,7 @@ class App: Component<Props, AppState>() {
                         orderStateReload(route, params, location)
                     }
                     state.pageStateChanged = false
-                    renderPage<M, S>()
+                    renderPage()
                 } else {
                     state.pageStateChanged = false
                     state.pageState = route.controller.getInitialState(url)
@@ -100,7 +100,7 @@ class App: Component<Props, AppState>() {
     }
 
     @Suppress("UNCHECKED_CAST")
-    private fun <S> orderStateReload(route: AppConfig.Route<*, S>, params: Params, location: Location) {
+    private fun <S> orderStateReload(route: AppConfig.Route<S>, params: Params, location: Location) {
         MainScope().launch {
             val controllerResult =
                 route.controller.get(
@@ -125,12 +125,12 @@ class App: Component<Props, AppState>() {
     }
 
     @Suppress("UNCHECKED_CAST")
-    private fun <M, S> ChildrenBuilder.renderPage() {
+    private fun ChildrenBuilder.renderPage() {
         return if (state.controllerResult!!.isModelAndView) {
-            val component = state.controllerResult!!.view as KClass<Component<PageRProps<M, S>, State>>
+            val component = state.controllerResult!!.view!! as KClass<out Component<PageRProps<Any?, *>, out State>>
+            // view must be not null if isModelAndView == true
             component.react {
-                model = state.controllerResult!!.model as M
-                //attrs.state = state.pageState!! as S
+                model = state.controllerResult!!.model
                 updateState = {
                     setState({state ->
                         state.pageState = it

--- a/src/main/kotlin/pogolitics/App.kt
+++ b/src/main/kotlin/pogolitics/App.kt
@@ -23,7 +23,7 @@ import react.dom.html.ReactHTML.img
 import kotlin.reflect.KClass
 
 external interface AppState : State {
-    var controllerResult: LooselyTypedControllerResult?
+    var controllerResult: ControllerResult?
     var url: String?
     var pageState: Any?
     var pageStateChanged: Boolean

--- a/src/main/kotlin/pogolitics/App.kt
+++ b/src/main/kotlin/pogolitics/App.kt
@@ -127,8 +127,8 @@ class App: Component<Props, AppState>() {
     @Suppress("UNCHECKED_CAST")
     private fun ChildrenBuilder.renderPage() {
         return if (state.controllerResult!!.isModelAndView) {
-            val component = state.controllerResult!!.view!! as KClass<out Component<PageRProps<Any?, *>, out State>>
             // view must be not null if isModelAndView == true
+            val component = state.controllerResult!!.view!! as KClass<out Component<PageRProps<Any?, *>, out State>>
             component.react {
                 model = state.controllerResult!!.model
                 updateState = {

--- a/src/main/kotlin/pogolitics/AppConfig.kt
+++ b/src/main/kotlin/pogolitics/AppConfig.kt
@@ -16,13 +16,13 @@ class AppConfig {
     private val pokemonController = SinglePokemonController(api, pokemonIndexService)
 
     // TODO later: move path to controller as well
-    val routing: List<Route<out Any, out Any>> = listOf(
+    val routing: List<Route<out Any>> = listOf(
         Route("/", true, homePageController),
         Route("/pokemon", true, pokemonListController),
         Route("/pokemon/:pokedexNumber", false, pokemonController)
     )
 
-    class Route<M, S>(
+    class Route<S>(
         val path: String,
         val exact: Boolean,
         val controller: Controller<S>

--- a/src/main/kotlin/pogolitics/AppConfig.kt
+++ b/src/main/kotlin/pogolitics/AppConfig.kt
@@ -25,7 +25,7 @@ class AppConfig {
     class Route<M, S>(
         val path: String,
         val exact: Boolean,
-        val controller: Controller<M, S>
+        val controller: Controller<S>
     )
 
 }

--- a/src/main/kotlin/pogolitics/ControllerResult.kt
+++ b/src/main/kotlin/pogolitics/ControllerResult.kt
@@ -5,13 +5,9 @@ import react.Props
 import react.State
 import kotlin.reflect.KClass
 
-typealias LooselyTypedControllerResult = ControllerResult<*, *>
+typealias ControllerResult = TypedControllerResult<*, *>
 
-class WControllerResult {
-
-}
-
-class ControllerResult<
+class TypedControllerResult<
     M,
     out V: View<M>
 > private constructor(
@@ -21,8 +17,8 @@ class ControllerResult<
     val notFoundReason: String?
 ) {
     companion object {
-        fun <M, V: View<M>> modelAndView(model: M, view: V): ControllerResult<*, *>  {
-            return ControllerResult(
+        fun <M, V: View<M>> modelAndView(model: M, view: V): TypedControllerResult<*, *>  {
+            return TypedControllerResult(
                 model = model,
                 view = view,
                 isModelAndView = true,
@@ -30,8 +26,8 @@ class ControllerResult<
             )
         }
 
-        fun notFound(reason: String): ControllerResult<*, *> {
-            return ControllerResult(
+        fun notFound(reason: String): TypedControllerResult<*, *> {
+            return TypedControllerResult(
                 model = null,
                 view = null,
                 isModelAndView = false,

--- a/src/main/kotlin/pogolitics/ControllerResult.kt
+++ b/src/main/kotlin/pogolitics/ControllerResult.kt
@@ -7,12 +7,12 @@ import kotlin.reflect.KClass
 
 interface ControllerResult {
     val model: Any?
-    val view: Any?
+    val view: View?
     val isModelAndView: Boolean
     val notFoundReason: String?
 
     companion object {
-        fun <M, V: View<M>> modelAndView(model: M, view: V): ControllerResult  {
+        fun <M, V: TypedView<M>> modelAndView(model: M, view: V): ControllerResult  {
             return TypedControllerResult(
                 model = model,
                 view = view,
@@ -31,7 +31,7 @@ interface ControllerResult {
         }
     }
 
-    private class TypedControllerResult<M, out V: View<M>>(
+    private class TypedControllerResult<M, out V: TypedView<out M>>(
         override val model: M?,
         override val view: V?,
         override val isModelAndView: Boolean,
@@ -39,7 +39,9 @@ interface ControllerResult {
     ): ControllerResult
 }
 
-private typealias View <M> = KClass<out Component<out PageRProps<M, *>, out State>>
+private typealias TypedView<M> = KClass<out Component<out PageRProps<M, *>, out State>>
+
+typealias View = TypedView<out Any?>
 
 interface PageRProps<M, S> : Props {
     var model: M

--- a/src/main/kotlin/pogolitics/ControllerResult.kt
+++ b/src/main/kotlin/pogolitics/ControllerResult.kt
@@ -5,6 +5,12 @@ import react.Props
 import react.State
 import kotlin.reflect.KClass
 
+typealias LooselyTypedControllerResult = ControllerResult<*, *>
+
+class WControllerResult {
+
+}
+
 class ControllerResult<
     M,
     out V: View<M>
@@ -15,7 +21,7 @@ class ControllerResult<
     val notFoundReason: String?
 ) {
     companion object {
-        fun <M, V: View<M>> modelAndView(model: M, view: V): ControllerResult<M, V>  {
+        fun <M, V: View<M>> modelAndView(model: M, view: V): ControllerResult<*, *>  {
             return ControllerResult(
                 model = model,
                 view = view,
@@ -24,7 +30,7 @@ class ControllerResult<
             )
         }
 
-        fun <M, V: View<M>> notFound(reason: String): ControllerResult<M, V> {
+        fun notFound(reason: String): ControllerResult<*, *> {
             return ControllerResult(
                 model = null,
                 view = null,

--- a/src/main/kotlin/pogolitics/ControllerResult.kt
+++ b/src/main/kotlin/pogolitics/ControllerResult.kt
@@ -5,19 +5,14 @@ import react.Props
 import react.State
 import kotlin.reflect.KClass
 
-typealias ControllerResult = TypedControllerResult<*, *>
-
-class TypedControllerResult<
-    M,
-    out V: View<M>
-> private constructor(
-    val model: M?,
-    val view: V?,
-    val isModelAndView: Boolean,
+interface ControllerResult {
+    val model: Any?
+    val view: Any?
+    val isModelAndView: Boolean
     val notFoundReason: String?
-) {
+
     companion object {
-        fun <M, V: View<M>> modelAndView(model: M, view: V): TypedControllerResult<*, *>  {
+        fun <M, V: View<M>> modelAndView(model: M, view: V): ControllerResult  {
             return TypedControllerResult(
                 model = model,
                 view = view,
@@ -26,7 +21,7 @@ class TypedControllerResult<
             )
         }
 
-        fun notFound(reason: String): TypedControllerResult<*, *> {
+        fun notFound(reason: String): ControllerResult {
             return TypedControllerResult(
                 model = null,
                 view = null,
@@ -35,15 +30,18 @@ class TypedControllerResult<
             )
         }
     }
+
+    private class TypedControllerResult<M, out V: View<M>>(
+        override val model: M?,
+        override val view: V?,
+        override val isModelAndView: Boolean,
+        override val notFoundReason: String?
+    ): ControllerResult
 }
 
-typealias View <M> = KClass<out Component<out PageRProps<M, *>, out State>>
+private typealias View <M> = KClass<out Component<out PageRProps<M, *>, out State>>
 
 interface PageRProps<M, S> : Props {
     var model: M
     var updateState: (S) -> Unit
-}
-
-interface PageRState<T> : State {
-    var data: T?
 }

--- a/src/main/kotlin/pogolitics/controller/Controller.kt
+++ b/src/main/kotlin/pogolitics/controller/Controller.kt
@@ -2,7 +2,6 @@ package pogolitics.controller
 
 import org.w3c.dom.url.URLSearchParams
 import pogolitics.ControllerResult
-import pogolitics.TypedControllerResult
 import react.router.Params
 
 interface Controller<M, S> {

--- a/src/main/kotlin/pogolitics/controller/Controller.kt
+++ b/src/main/kotlin/pogolitics/controller/Controller.kt
@@ -4,7 +4,7 @@ import org.w3c.dom.url.URLSearchParams
 import pogolitics.ControllerResult
 import react.router.Params
 
-interface Controller<M, S> {
+interface Controller<S> {
     fun getInitialState(url: String): S
     suspend fun get(
         props: Params,

--- a/src/main/kotlin/pogolitics/controller/Controller.kt
+++ b/src/main/kotlin/pogolitics/controller/Controller.kt
@@ -2,11 +2,8 @@ package pogolitics.controller
 
 import org.w3c.dom.url.URLSearchParams
 import pogolitics.ControllerResult
-import pogolitics.PageRProps
-import react.Component
-import react.State
+import pogolitics.TypedControllerResult
 import react.router.Params
-import kotlin.reflect.KClass
 
 interface Controller<M, S> {
     fun getInitialState(url: String): S
@@ -14,5 +11,5 @@ interface Controller<M, S> {
         props: Params,
         params: URLSearchParams,
         state: S
-    ): ControllerResult<*, *>
+    ): ControllerResult
 }

--- a/src/main/kotlin/pogolitics/controller/Controller.kt
+++ b/src/main/kotlin/pogolitics/controller/Controller.kt
@@ -14,5 +14,5 @@ interface Controller<M, S> {
         props: Params,
         params: URLSearchParams,
         state: S
-    ): ControllerResult<M, KClass<out Component<out PageRProps<M, S>, out State>>>
+    ): ControllerResult<*, *>
 }

--- a/src/main/kotlin/pogolitics/controller/HomePageController.kt
+++ b/src/main/kotlin/pogolitics/controller/HomePageController.kt
@@ -15,7 +15,7 @@ class HomePageController(private val pokemonIndexService: PokemonIndexService): 
         props: Params,
         params: URLSearchParams,
         state: Unit
-    ): ControllerResult<HomePageModel, KClass<HomePage>> {
+    ): ControllerResult<*, *> {
         return ControllerResult.modelAndView(
             view = HomePage::class,
             model = HomePageModel(pokemonIndexService.getPokemonList())

--- a/src/main/kotlin/pogolitics/controller/HomePageController.kt
+++ b/src/main/kotlin/pogolitics/controller/HomePageController.kt
@@ -1,11 +1,10 @@
 package pogolitics.controller
 
 import org.w3c.dom.url.URLSearchParams
-import pogolitics.ControllerResult
+import pogolitics.TypedControllerResult
 import pogolitics.model.HomePageModel
 import pogolitics.view.HomePage
 import react.router.Params
-import kotlin.reflect.KClass
 
 class HomePageController(private val pokemonIndexService: PokemonIndexService): Controller<HomePageModel, Unit> {
 
@@ -15,8 +14,8 @@ class HomePageController(private val pokemonIndexService: PokemonIndexService): 
         props: Params,
         params: URLSearchParams,
         state: Unit
-    ): ControllerResult<*, *> {
-        return ControllerResult.modelAndView(
+    ): TypedControllerResult<*, *> {
+        return TypedControllerResult.modelAndView(
             view = HomePage::class,
             model = HomePageModel(pokemonIndexService.getPokemonList())
         )

--- a/src/main/kotlin/pogolitics/controller/HomePageController.kt
+++ b/src/main/kotlin/pogolitics/controller/HomePageController.kt
@@ -6,7 +6,7 @@ import pogolitics.model.HomePageModel
 import pogolitics.view.HomePage
 import react.router.Params
 
-class HomePageController(private val pokemonIndexService: PokemonIndexService): Controller<HomePageModel, Unit> {
+class HomePageController(private val pokemonIndexService: PokemonIndexService): Controller<Unit> {
 
     override fun getInitialState(url: String) {}
 

--- a/src/main/kotlin/pogolitics/controller/HomePageController.kt
+++ b/src/main/kotlin/pogolitics/controller/HomePageController.kt
@@ -1,7 +1,7 @@
 package pogolitics.controller
 
 import org.w3c.dom.url.URLSearchParams
-import pogolitics.TypedControllerResult
+import pogolitics.ControllerResult
 import pogolitics.model.HomePageModel
 import pogolitics.view.HomePage
 import react.router.Params
@@ -14,8 +14,8 @@ class HomePageController(private val pokemonIndexService: PokemonIndexService): 
         props: Params,
         params: URLSearchParams,
         state: Unit
-    ): TypedControllerResult<*, *> {
-        return TypedControllerResult.modelAndView(
+    ): ControllerResult {
+        return ControllerResult.modelAndView(
             view = HomePage::class,
             model = HomePageModel(pokemonIndexService.getPokemonList())
         )

--- a/src/main/kotlin/pogolitics/controller/PokemonListController.kt
+++ b/src/main/kotlin/pogolitics/controller/PokemonListController.kt
@@ -1,7 +1,7 @@
 package pogolitics.controller
 
 import org.w3c.dom.url.URLSearchParams
-import pogolitics.TypedControllerResult
+import pogolitics.ControllerResult
 import pogolitics.model.PokemonListModel
 import pogolitics.view.PokemonListPage
 import react.router.Params
@@ -14,12 +14,10 @@ class PokemonListController(private val pokemonIndexService: PokemonIndexService
         props: Params,
         params: URLSearchParams,
         state: Unit
-    ): TypedControllerResult<*, *> =
-        TypedControllerResult.modelAndView(
+    ): ControllerResult =
+        ControllerResult.modelAndView(
             view = PokemonListPage::class,
             model = PokemonListModel(pokemonIndexService.getPokemonList())
         )
-
-
 
 }

--- a/src/main/kotlin/pogolitics/controller/PokemonListController.kt
+++ b/src/main/kotlin/pogolitics/controller/PokemonListController.kt
@@ -1,11 +1,10 @@
 package pogolitics.controller
 
 import org.w3c.dom.url.URLSearchParams
-import pogolitics.ControllerResult
+import pogolitics.TypedControllerResult
 import pogolitics.model.PokemonListModel
 import pogolitics.view.PokemonListPage
 import react.router.Params
-import kotlin.reflect.KClass
 
 class PokemonListController(private val pokemonIndexService: PokemonIndexService) : Controller<PokemonListModel, Unit> {
 
@@ -15,8 +14,8 @@ class PokemonListController(private val pokemonIndexService: PokemonIndexService
         props: Params,
         params: URLSearchParams,
         state: Unit
-    ): ControllerResult<*, *> =
-        ControllerResult.modelAndView(
+    ): TypedControllerResult<*, *> =
+        TypedControllerResult.modelAndView(
             view = PokemonListPage::class,
             model = PokemonListModel(pokemonIndexService.getPokemonList())
         )

--- a/src/main/kotlin/pogolitics/controller/PokemonListController.kt
+++ b/src/main/kotlin/pogolitics/controller/PokemonListController.kt
@@ -15,7 +15,7 @@ class PokemonListController(private val pokemonIndexService: PokemonIndexService
         props: Params,
         params: URLSearchParams,
         state: Unit
-    ): ControllerResult<PokemonListModel, KClass<PokemonListPage>> =
+    ): ControllerResult<*, *> =
         ControllerResult.modelAndView(
             view = PokemonListPage::class,
             model = PokemonListModel(pokemonIndexService.getPokemonList())

--- a/src/main/kotlin/pogolitics/controller/PokemonListController.kt
+++ b/src/main/kotlin/pogolitics/controller/PokemonListController.kt
@@ -6,7 +6,7 @@ import pogolitics.model.PokemonListModel
 import pogolitics.view.PokemonListPage
 import react.router.Params
 
-class PokemonListController(private val pokemonIndexService: PokemonIndexService) : Controller<PokemonListModel, Unit> {
+class PokemonListController(private val pokemonIndexService: PokemonIndexService) : Controller<Unit> {
 
     override fun getInitialState(url: String) {}
 

--- a/src/main/kotlin/pogolitics/controller/SinglePokemonController.kt
+++ b/src/main/kotlin/pogolitics/controller/SinglePokemonController.kt
@@ -18,7 +18,7 @@ import kotlin.reflect.KClass
 class SinglePokemonController(
     private val api: Api,
     private val pokemonIndexService: PokemonIndexService
-): Controller<SinglePokemonModel, PokemonIndividualValuesState> {
+): Controller<Any, PokemonIndividualValuesState> {
 
     override fun getInitialState(url: String) =
         PokemonIndividualValuesState(
@@ -33,7 +33,7 @@ class SinglePokemonController(
         props: Params,
         params: URLSearchParams,
         state: PokemonIndividualValuesState
-    ): ControllerResult<SinglePokemonModel, KClass<SinglePokemonPage>> {
+    ): ControllerResult<*, *> {
         return coroutineScope {
             val form = params.get("form")
             val mode = BattleMode.fromString(params.get("mode") ?: "pvp") // TODO display some kind of error page for invalid values

--- a/src/main/kotlin/pogolitics/controller/SinglePokemonController.kt
+++ b/src/main/kotlin/pogolitics/controller/SinglePokemonController.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import org.w3c.dom.url.URLSearchParams
-import pogolitics.TypedControllerResult
+import pogolitics.ControllerResult
 import pogolitics.api.*
 import pogolitics.model.*
 import pogolitics.model.SinglePokemonModel.PokemonIndividualStatistics
@@ -32,7 +32,7 @@ class SinglePokemonController(
         props: Params,
         params: URLSearchParams,
         state: PokemonIndividualValuesState
-    ): TypedControllerResult<*, *> {
+    ): ControllerResult {
         return coroutineScope {
             val form = params.get("form")
             val mode = BattleMode.fromString(params.get("mode") ?: "pvp") // TODO display some kind of error page for invalid values
@@ -46,7 +46,7 @@ class SinglePokemonController(
             }
             maybePokemon.await()?.let { pokemon ->
                 val pokemonStats = calculatePokemonStatistics(pokemon, state)
-                TypedControllerResult.modelAndView(
+                ControllerResult.modelAndView(
                     view = SinglePokemonPage::class,
                     model = SinglePokemonModel(
                         mode = mode,
@@ -63,7 +63,7 @@ class SinglePokemonController(
                         focusedElement = state.focus
                     )
                 )
-            } ?: TypedControllerResult.notFound("No such pokemon")
+            } ?: ControllerResult.notFound("No such pokemon")
         }
     }
 

--- a/src/main/kotlin/pogolitics/controller/SinglePokemonController.kt
+++ b/src/main/kotlin/pogolitics/controller/SinglePokemonController.kt
@@ -17,7 +17,7 @@ import kotlin.math.sqrt
 class SinglePokemonController(
     private val api: Api,
     private val pokemonIndexService: PokemonIndexService
-): Controller<Any, PokemonIndividualValuesState> {
+): Controller<PokemonIndividualValuesState> {
 
     override fun getInitialState(url: String) =
         PokemonIndividualValuesState(

--- a/src/main/kotlin/pogolitics/controller/SinglePokemonController.kt
+++ b/src/main/kotlin/pogolitics/controller/SinglePokemonController.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import org.w3c.dom.url.URLSearchParams
-import pogolitics.ControllerResult
+import pogolitics.TypedControllerResult
 import pogolitics.api.*
 import pogolitics.model.*
 import pogolitics.model.SinglePokemonModel.PokemonIndividualStatistics
@@ -13,7 +13,6 @@ import pogolitics.model.SinglePokemonModel.VariablePokemonStatistics
 import pogolitics.view.SinglePokemonPage
 import react.router.Params
 import kotlin.math.sqrt
-import kotlin.reflect.KClass
 
 class SinglePokemonController(
     private val api: Api,
@@ -33,7 +32,7 @@ class SinglePokemonController(
         props: Params,
         params: URLSearchParams,
         state: PokemonIndividualValuesState
-    ): ControllerResult<*, *> {
+    ): TypedControllerResult<*, *> {
         return coroutineScope {
             val form = params.get("form")
             val mode = BattleMode.fromString(params.get("mode") ?: "pvp") // TODO display some kind of error page for invalid values
@@ -47,7 +46,7 @@ class SinglePokemonController(
             }
             maybePokemon.await()?.let { pokemon ->
                 val pokemonStats = calculatePokemonStatistics(pokemon, state)
-                ControllerResult.modelAndView(
+                TypedControllerResult.modelAndView(
                     view = SinglePokemonPage::class,
                     model = SinglePokemonModel(
                         mode = mode,
@@ -64,7 +63,7 @@ class SinglePokemonController(
                         focusedElement = state.focus
                     )
                 )
-            } ?: ControllerResult.notFound("No such pokemon")
+            } ?: TypedControllerResult.notFound("No such pokemon")
         }
     }
 


### PR DESCRIPTION
It used to be very cumbersome to define a controller with so many template parameters. Now parameters checking is only enforced in factory methods of ControllerResult, where they really matter - the only point of type checking is really to make sure that view that is returned is compatible with returned model.